### PR TITLE
Sitemaps for SITEURL with path elements not generated properly

### DIFF
--- a/extended-sitemap/__init__.py
+++ b/extended-sitemap/__init__.py
@@ -72,6 +72,9 @@ class SitemapGenerator(object):
         self.context = context
         self.timezone = timezone(settings.get('TIMEZONE'))
         self.url_site = settings.get('SITEURL')
+        # Pelican strips off trailing slashes during settings initialization.
+        # The later used urljoin function strips of path elements not ending with a trailing slash, 
+        # a slash is added here if it is not already present
         if not self.url_site.endswith('/'):
             self.url_site += '/'
         self.settings = settings.get('EXTENDED_SITEMAP_PLUGIN', self.settings_default)


### PR DESCRIPTION
Pelican is able to be used with a SITEURL containing a path after the domain:

``` python
SITEURL = 'http://example.com/path'
```

If you have a setup like this, the sitemaps are not generated properly. This comes from _urljoin_ function used in the code, that strips off path elements without trailing slash.
Adding a trailing slash to SITEURL is also not an option, because this is stripped off by Pelican.

I added a check at the point, where SITEURL is read from Pelican settings. If the value does not end with a slash, it is simply added.
This is safe for SITEURL values with and without path elements.
