### PR TITLE
Use/fix custom article URL

### DIFF
--- a/extended_sitemap/__init__.py
+++ b/extended_sitemap/__init__.py
@@ -128,7 +128,11 @@ class SitemapGenerator(object):
 
         # process articles
         for article in articles_sorted:
-            urls += self.__create_url_node_for_content(article, 'articles')
+            urls += self.__create_url_node_for_content(
+                article,
+                'articles',
+                url=urljoin(self.url_site, article.url)
+            )
 
         # process pages
         for page in pages_sorted:


### PR DESCRIPTION
All my articles have a custom URL ("URL" and "save_as") but extended_sitemap just used slug and ".html" suffix.