### PR TITLE
Add Framework :: Pelican :: Plugins classifer for PyPI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ setup(
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Environment :: Console',
+        'Framework :: Pelican :: Plugins',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
         'Natural Language :: English',


### PR DESCRIPTION
The classifier was added relatively recently to PyPI to hopefully make it easier to find Pelican plugins.